### PR TITLE
move mlu passes forward

### DIFF
--- a/lite/core/mir/mlu_postprocess_pass.h
+++ b/lite/core/mir/mlu_postprocess_pass.h
@@ -79,6 +79,8 @@ class MLUPostprocessPass : public ProgramPass {
                             const Type** arg_type,
                             SSAGraph* graph);
 
+  void ModifyInputOutputDataType(SSAGraph* graph);
+
   void ModifyLayout(SSAGraph* graph);
 
   bool NeedInsert(Node* node, const Type* inst_type);

--- a/lite/core/op_registry.cc
+++ b/lite/core/op_registry.cc
@@ -180,6 +180,8 @@ KernelRegistry::KernelRegistry()
   INIT_FOR(kHost, kInt64, kAny);
 
   INIT_FOR(kX86, kFloat, kNCHW);
+  INIT_FOR(kX86, kFP16, kNCHW);
+  INIT_FOR(kX86, kInt8, kNCHW);
   INIT_FOR(kX86, kAny, kNCHW);
   INIT_FOR(kX86, kAny, kAny);
   INIT_FOR(kX86, kInt64, kNCHW);

--- a/lite/core/op_registry.h
+++ b/lite/core/op_registry.h
@@ -121,6 +121,9 @@ class KernelRegistry final {
                                       PRECISION(kFloat),
                                       DATALAYOUT(kNCHW)> *,  //
               KernelRegistryForTarget<TARGET(kX86),
+                                      PRECISION(kFP16),
+                                      DATALAYOUT(kNCHW)> *,  //
+              KernelRegistryForTarget<TARGET(kX86),
                                       PRECISION(kInt8),
                                       DATALAYOUT(kNCHW)> *,  //
               KernelRegistryForTarget<TARGET(kHost),

--- a/lite/core/optimizer.h
+++ b/lite/core/optimizer.h
@@ -90,8 +90,12 @@ class Optimizer {
            "xpu_subgraph_pass",
            "bm_subgraph_pass",
            "rknpu_subgraph_pass",
+           "mlu_subgraph_pass",
+
            "static_kernel_pick_pass",        // pick original kernel from graph
            "variable_place_inference_pass",  // inference arg/var's
+
+           "mlu_postprocess_pass",
            // info(target/precision/layout/device)
            // using kernel info
            "argument_type_display_pass",  // debug pass: show arg-type-node's
@@ -121,12 +125,8 @@ class Optimizer {
            "variable_place_inference_pass",  //
            "argument_type_display_pass",
 
-           "mlu_subgraph_pass",
-
            "runtime_context_assign_pass",
            "argument_type_display_pass",
-
-           "mlu_postprocess_pass",
 
            "memory_optimize_pass"}};
 

--- a/lite/kernels/mlu/bridges/dropout_op.cc
+++ b/lite/kernels/mlu/bridges/dropout_op.cc
@@ -33,10 +33,15 @@ int DropoutConverter(void* ctx, OpLite* op, KernelBase* kernel) {
   // Create act node and set params from op
   auto x_var_name = op_info->Input("X").front();
   auto out_var_name = op_info->Output("Out").front();
+  auto mask_var_name = op_info->Output("Mask").front();
   auto output = scope->FindVar(out_var_name)->GetMutable<Tensor>();
   auto output_dims = output->dims().Vectorize();
   auto output_tensor = graph->AddNode(
       out_var_name, output_dims, CNML_TENSOR, CNML_NCHW, graph->FPType());
+  auto mask = scope->FindVar(mask_var_name)->GetMutable<Tensor>();
+  auto mask_dims = mask->dims().Vectorize();
+  auto mask_tensor = graph->AddNode(
+      mask_var_name, mask_dims, CNML_TENSOR, CNML_NCHW, graph->FPType());
 
   // is_test is true by default
   // if(op_info->HasAttr("is_test")){

--- a/lite/kernels/mlu/bridges/dropout_op_test.cc
+++ b/lite/kernels/mlu/bridges/dropout_op_test.cc
@@ -85,9 +85,9 @@ void test_dropout(int bs,
   opdesc.SetAttr("seed", seed);
   opdesc.SetAttr("dropout_implementation", dropout_implementation);
   opdesc.SetAttr("dropout_prob", dropout_prob);
+  VLOG(6) << "mask: " << mask->dims()[0] << std::endl;
   // create and convert op to MLU model, then run it on MLU
   auto op = CreateOp<operators::DropoutOp>(opdesc, &scope);
-  VLOG(6) << "mask: " << mask << std::endl;
   dropout_ref(op);
   out_ref->CopyDataFrom(*out);
 

--- a/lite/kernels/mlu/io_copy_compute.cc
+++ b/lite/kernels/mlu/io_copy_compute.cc
@@ -102,8 +102,14 @@ REGISTER_LITE_KERNEL(
     kNHWC,
     paddle::lite::kernels::mlu::IoCopyHostToMluCompute<PRECISION(kFloat)>,
     host_to_device_kFloat)
-    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kHost))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kMLU))})
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kHost),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kAny))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kMLU),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kAny))})
     .Finalize();
 
 REGISTER_LITE_KERNEL(
@@ -113,8 +119,14 @@ REGISTER_LITE_KERNEL(
     kNHWC,
     paddle::lite::kernels::mlu::IoCopyHostToMluCompute<PRECISION(kFP16)>,
     host_to_device_kFP16)
-    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kHost))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kMLU))})
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kHost),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kAny))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kMLU),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kAny))})
     .Finalize();
 
 REGISTER_LITE_KERNEL(
@@ -124,8 +136,14 @@ REGISTER_LITE_KERNEL(
     kNHWC,
     paddle::lite::kernels::mlu::IoCopyMluToHostCompute<PRECISION(kFloat)>,
     device_to_host_kFloat)
-    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kMLU))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost))})
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kMLU),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kAny))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kHost),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kAny))})
     .Finalize();
 
 REGISTER_LITE_KERNEL(
@@ -135,6 +153,12 @@ REGISTER_LITE_KERNEL(
     kNHWC,
     paddle::lite::kernels::mlu::IoCopyMluToHostCompute<PRECISION(kFP16)>,
     device_to_host_kFP16)
-    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kMLU))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost))})
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kMLU),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kAny))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kHost),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kAny))})
     .Finalize();

--- a/lite/kernels/mlu/layout_compute.cc
+++ b/lite/kernels/mlu/layout_compute.cc
@@ -24,9 +24,9 @@ namespace mlu {}  // namespace mlu
 
 REGISTER_LITE_KERNEL(
     layout,
-    kMLU,
+    kX86,
     kFloat,
-    kNHWC,
+    kNCHW,
     paddle::lite::kernels::mlu::LayoutNhwcToNchwCompute<PRECISION(kFloat)>,
     def_layout_nhwc2nchw_fp32)
     .BindInput("Input",
@@ -41,9 +41,9 @@ REGISTER_LITE_KERNEL(
 
 REGISTER_LITE_KERNEL(
     layout,
-    kMLU,
+    kX86,
     kFP16,
-    kNHWC,
+    kNCHW,
     paddle::lite::kernels::mlu::LayoutNhwcToNchwCompute<PRECISION(kFP16)>,
     def_layout_nhwc2nchw_fp16)
     .BindInput("Input",
@@ -58,9 +58,9 @@ REGISTER_LITE_KERNEL(
 
 REGISTER_LITE_KERNEL(
     layout,
-    kMLU,
+    kX86,
     kFloat,
-    kNHWC,
+    kNCHW,
     paddle::lite::kernels::mlu::LayoutNchwToNhwcCompute<PRECISION(kFloat)>,
     def_layout_nchw2nhwc_fp32)
     .BindInput("Input",
@@ -75,9 +75,9 @@ REGISTER_LITE_KERNEL(
 
 REGISTER_LITE_KERNEL(
     layout,
-    kMLU,
+    kX86,
     kFP16,
-    kNHWC,
+    kNCHW,
     paddle::lite::kernels::mlu::LayoutNchwToNhwcCompute<PRECISION(kFP16)>,
     def_layout_nchw2nhwc_fp16)
     .BindInput("Input",
@@ -92,11 +92,11 @@ REGISTER_LITE_KERNEL(
 
 REGISTER_LITE_KERNEL(
     layout,
-    kMLU,
+    kX86,
     kInt8,
-    kNHWC,
+    kNCHW,
     paddle::lite::kernels::mlu::LayoutNchwToNhwcCompute<PRECISION(kInt8)>,
-    def_layout_nchw2nhwc_fp32_int8)
+    def_layout_nchw2nhwc_int8)
     .BindInput("Input",
                {LiteType::GetTensorTy(TARGET(kHost),
                                       PRECISION(kInt8),

--- a/lite/kernels/mlu/layout_compute.h
+++ b/lite/kernels/mlu/layout_compute.h
@@ -73,7 +73,7 @@ inline void LayoutTransCompute(const int dim,
 
 template <PrecisionType Precision>
 class LayoutNchwToNhwcCompute
-    : public KernelLite<TARGET(kMLU), Precision, DATALAYOUT(kNHWC)> {
+    : public KernelLite<TARGET(kX86), Precision, DATALAYOUT(kNCHW)> {
  public:
   using param_t = operators::LayoutParam;
 
@@ -122,7 +122,7 @@ class LayoutNchwToNhwcCompute
 
 template <PrecisionType Precision>
 class LayoutNhwcToNchwCompute
-    : public KernelLite<TARGET(kMLU), Precision, DATALAYOUT(kNHWC)> {
+    : public KernelLite<TARGET(kX86), Precision, DATALAYOUT(kNCHW)> {
  public:
   using param_t = operators::LayoutParam;
 

--- a/lite/kernels/mlu/subgraph_compute.cc
+++ b/lite/kernels/mlu/subgraph_compute.cc
@@ -36,8 +36,14 @@ REGISTER_LITE_KERNEL(
     kNHWC,
     paddle::lite::kernels::mlu::SubgraphCompute<PRECISION(kFloat)>,
     def_kFloat)
-    .BindInput("Inputs", {LiteType::GetTensorTy(TARGET(kMLU))})
-    .BindOutput("Outputs", {LiteType::GetTensorTy(TARGET(kMLU))})
+    .BindInput("Inputs",
+               {LiteType::GetTensorTy(TARGET(kMLU),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kAny))})
+    .BindOutput("Outputs",
+                {LiteType::GetTensorTy(TARGET(kMLU),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kAny))})
     .Finalize();
 
 REGISTER_LITE_KERNEL(
@@ -47,6 +53,12 @@ REGISTER_LITE_KERNEL(
     kNHWC,
     paddle::lite::kernels::mlu::SubgraphCompute<PRECISION(kFP16)>,
     def_FP16)
-    .BindInput("Inputs", {LiteType::GetTensorTy(TARGET(kMLU))})
-    .BindOutput("Outputs", {LiteType::GetTensorTy(TARGET(kMLU))})
+    .BindInput("Inputs",
+               {LiteType::GetTensorTy(TARGET(kMLU),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kAny))})
+    .BindOutput("Outputs",
+                {LiteType::GetTensorTy(TARGET(kMLU),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kAny))})
     .Finalize();


### PR DESCRIPTION
往前调整mlu的两个pass位置， 保证static-kernle-pick pass时mlu的subgraph已经生成；
使用时，需要注意由于调整layout算子注册到了cpu上config设置valid place时的接口有变化，参考：
  std::vector<Place> valid_places{
    Place{TARGET(kX86), PRECISION(kFloat)},   // 建议必选
    Place{TARGET(kX86), PRECISION(kFP16)},  // 建议必选
    Place{TARGET(kX86), PRECISION(kInt8)},  // 建议必选
    //Place{TARGET(kMLU), PRECISION(kFloat), DATALAYOUT(kNHWC)}   //和下面二选一
    Place{TARGET(kMLU), PRECISION(kFP16), DATALAYOUT(kNHWC)}  //和上面二选一
  };
