### PR TITLE
fix(place): add x86 nhwc place in subgraph_pass

### DIFF
--- a/lite/core/op_registry.cc
+++ b/lite/core/op_registry.cc
@@ -182,6 +182,9 @@ KernelRegistry::KernelRegistry()
   INIT_FOR(kX86, kFloat, kNCHW);
   INIT_FOR(kX86, kFP16, kNCHW);
   INIT_FOR(kX86, kInt8, kNCHW);
+  INIT_FOR(kX86, kFloat, kNHWC);
+  INIT_FOR(kX86, kFP16, kNHWC);
+  INIT_FOR(kX86, kInt8, kNHWC);
   INIT_FOR(kX86, kAny, kNCHW);
   INIT_FOR(kX86, kAny, kAny);
   INIT_FOR(kX86, kInt64, kNCHW);

--- a/lite/core/op_registry.h
+++ b/lite/core/op_registry.h
@@ -126,6 +126,15 @@ class KernelRegistry final {
               KernelRegistryForTarget<TARGET(kX86),
                                       PRECISION(kInt8),
                                       DATALAYOUT(kNCHW)> *,  //
+              KernelRegistryForTarget<TARGET(kX86),
+                                      PRECISION(kFloat),
+                                      DATALAYOUT(kNHWC)> *,  //
+              KernelRegistryForTarget<TARGET(kX86),
+                                      PRECISION(kFP16),
+                                      DATALAYOUT(kNHWC)> *,  //
+              KernelRegistryForTarget<TARGET(kX86),
+                                      PRECISION(kInt8),
+                                      DATALAYOUT(kNHWC)> *,  //
               KernelRegistryForTarget<TARGET(kHost),
                                       PRECISION(kFloat),
                                       DATALAYOUT(kNCHW)> *,  //

--- a/lite/kernels/x86/cast_compute.cc
+++ b/lite/kernels/x86/cast_compute.cc
@@ -20,7 +20,10 @@ REGISTER_LITE_KERNEL(cast,
                      kNCHW,
                      paddle::lite::kernels::x86::CastCompute<float>,
                      def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kX86))})
+    .BindInput("X",
+               {LiteType::GetTensorTy(TARGET(kX86),
+                                      PRECISION(kFloat),
+                                      DATALAYOUT(kAny))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})
     .Finalize();
 
@@ -31,6 +34,9 @@ REGISTER_LITE_KERNEL(
     kNCHW,
     paddle::lite::kernels::x86::CastCompute<::paddle::lite::fluid::float16>,
     fp16_to_any)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kFP16))})
+    .BindInput("X",
+               {LiteType::GetTensorTy(TARGET(kX86),
+                                      PRECISION(kFP16),
+                                      DATALAYOUT(kAny))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})
     .Finalize();


### PR DESCRIPTION
Since input tensor is modified to NHWC, which is not compatible to cast
kernel in NCHW layout, type_layout_cast_pass will insert a layout
instruction to transform data. Use NHWC cast kernel to avoid cast layout