### PR TITLE
(feat): add int32 io copy support

### DIFF
--- a/lite/core/mir/mlu_postprocess_pass.cc
+++ b/lite/core/mir/mlu_postprocess_pass.cc
@@ -21,6 +21,7 @@
 #include <vector>
 #include "lite/core/mir/graph_visualize_pass.h"
 #include "lite/core/mir/pass_registry.h"
+#include "lite/core/mir/subgraph/subgraph_detector.h"
 #include "lite/operators/subgraph_op.h"
 
 namespace paddle {
@@ -674,7 +675,8 @@ std::pair<bool, std::string> CheckInputAndInsert(Scope* scope,
   }
 
   if (!PrecisionCompatible(*tensor_type, *subgraph_type) &&
-      tensor_type->precision() != PRECISION(kInt8)) {
+      tensor_type->precision() != PRECISION(kInt8) &&
+      tensor_type->precision() != PRECISION(kInt32)) {
     auto cast_op = block_desc->AddOp<cpp::OpDesc>();
     auto cast_arg_name = string_format("%s/cast", cur_node.c_str());
     scope->Var(cast_arg_name);
@@ -915,6 +917,8 @@ void MLUPostprocessPass::Apply(const std::unique_ptr<SSAGraph>& graph) {
       }
     }
   }
+  // std::vector<std::vector<Node*>> subgraphs({graph->NodeTopologicalOrder()});
+  // SubgraphVisualizer(graph.get(), subgraphs)();
 }
 
 }  // namespace mir

--- a/lite/core/op_registry.cc
+++ b/lite/core/op_registry.cc
@@ -153,6 +153,8 @@ KernelRegistry::KernelRegistry()
   INIT_FOR(kMLU, kInt8, kNCHW);
   INIT_FOR(kMLU, kInt16, kNHWC);
   INIT_FOR(kMLU, kInt16, kNCHW);
+  INIT_FOR(kMLU, kInt32, kNHWC);
+  INIT_FOR(kMLU, kInt32, kNCHW);
 
   INIT_FOR(kHost, kAny, kNCHW);
   INIT_FOR(kHost, kAny, kNHWC);

--- a/lite/core/op_registry.h
+++ b/lite/core/op_registry.h
@@ -321,6 +321,12 @@ class KernelRegistry final {
                                       DATALAYOUT(kNHWC)> *,  //
               KernelRegistryForTarget<TARGET(kMLU),
                                       PRECISION(kInt16),
+                                      DATALAYOUT(kNCHW)> *,  //
+              KernelRegistryForTarget<TARGET(kMLU),
+                                      PRECISION(kInt32),
+                                      DATALAYOUT(kNHWC)> *,  //
+              KernelRegistryForTarget<TARGET(kMLU),
+                                      PRECISION(kInt32),
                                       DATALAYOUT(kNCHW)> *  //
               >;
 

--- a/lite/kernels/mlu/io_copy_compute.cc
+++ b/lite/kernels/mlu/io_copy_compute.cc
@@ -137,6 +137,23 @@ REGISTER_LITE_KERNEL(
 REGISTER_LITE_KERNEL(
     io_copy,
     kMLU,
+    kInt32,
+    kNHWC,
+    paddle::lite::kernels::mlu::IoCopyHostToMluCompute<PRECISION(kInt32)>,
+    host_to_device_kInt32)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kHost),
+                                      PRECISION(kInt32),
+                                      DATALAYOUT(kAny))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kMLU),
+                                       PRECISION(kInt32),
+                                       DATALAYOUT(kAny))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    io_copy,
+    kMLU,
     kFloat,
     kNHWC,
     paddle::lite::kernels::mlu::IoCopyMluToHostCompute<PRECISION(kFloat)>,


### PR DESCRIPTION
yolov3 模型需要img shape输入，类型是int32；
这次pr增加了 int32 的iocopy，同时，如果tensor是int32，那么cpu或者mlu上都不插入cast