### PR TITLE
(feat): add idenity cast eliminate pass, only remove int32 to int32 cast for now

### DIFF
--- a/lite/api/paddle_use_passes.h
+++ b/lite/api/paddle_use_passes.h
@@ -46,6 +46,7 @@ USE_MIR_PASS(multi_stream_analysis_pass);
 USE_MIR_PASS(elementwise_mul_constant_eliminate_pass)
 USE_MIR_PASS(npu_subgraph_pass);
 USE_MIR_PASS(xpu_subgraph_pass);
+USE_MIR_PASS(mlu_subgraph_pass);
 USE_MIR_PASS(identity_cast_eliminate_pass);
 USE_MIR_PASS(mlu_postprocess_pass);
 USE_MIR_PASS(weight_quantization_preprocess_pass);

--- a/lite/api/paddle_use_passes.h
+++ b/lite/api/paddle_use_passes.h
@@ -46,7 +46,7 @@ USE_MIR_PASS(multi_stream_analysis_pass);
 USE_MIR_PASS(elementwise_mul_constant_eliminate_pass)
 USE_MIR_PASS(npu_subgraph_pass);
 USE_MIR_PASS(xpu_subgraph_pass);
-USE_MIR_PASS(mlu_subgraph_pass);
+USE_MIR_PASS(identity_cast_eliminate_pass);
 USE_MIR_PASS(mlu_postprocess_pass);
 USE_MIR_PASS(weight_quantization_preprocess_pass);
 USE_MIR_PASS(quantized_op_attributes_inference_pass);

--- a/lite/core/mir/CMakeLists.txt
+++ b/lite/core/mir/CMakeLists.txt
@@ -24,6 +24,7 @@ lite_cc_library(mir_passes
       fusion/__xpu__resnet_fuse_pass.cc
       fusion/__xpu__multi_encoder_fuse_pass.cc
       elimination/identity_scale_eliminate_pass.cc
+      elimination/identity_cast_eliminate_pass.cc
       elimination/elementwise_mul_constant_eliminate_pass.cc
       static_kernel_pick_pass.cc
       variable_place_inference_pass.cc

--- a/lite/core/mir/elimination/identity_cast_eliminate_pass.cc
+++ b/lite/core/mir/elimination/identity_cast_eliminate_pass.cc
@@ -88,4 +88,4 @@ class IdentityCastEliminatePass : public ProgramPass {
 
 REGISTER_MIR_PASS(identity_cast_eliminate_pass,
                   paddle::lite::mir::IdentityCastEliminatePass)
-    .BindTargets({TARGET(kAny)});
+    .BindTargets({TARGET(kMLU)});

--- a/lite/core/mir/elimination/identity_cast_eliminate_pass.cc
+++ b/lite/core/mir/elimination/identity_cast_eliminate_pass.cc
@@ -1,0 +1,91 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/core/mir/pass.h"
+#include "lite/core/mir/pass_registry.h"
+#include "lite/core/mir/pattern_matcher_high_api.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+
+namespace {
+
+class CastEliminator : public FuseBase {
+ public:
+  explicit CastEliminator(const int dtype) : dtype_(dtype) {}
+  void BuildPattern() override {
+    // the previous op's output need updat
+    auto* pre_op = OpNode("preop")
+                       ->assert_is_not_op_type("conditional_block")
+                       ->assert_is_not_op_type("cast");
+
+    auto* x = VarNode("x")->assert_is_op_input("cast", "X");
+    auto* cast_op = OpNode("cast", "cast")
+                        ->assert_op_attr<int>("in_dtype", dtype_)
+                        ->assert_op_attr<int>("out_dtype", dtype_);
+    auto* out = VarNode("out")->assert_is_op_output("cast", "Out");
+    *pre_op >> *x >> *cast_op >> *out;
+    // The pre_op will be eliminated, and a new output-updated op will insert.
+  }
+
+ private:
+  void InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) override {
+    auto& pre_op = matched.at("preop")->AsStmt();
+    auto op_info = *pre_op.op_info();
+
+    op_info.UpdateAllOutputs(matched.at("x")->AsArg().name,
+                             matched.at("out")->AsArg().name);
+    pre_op.ResetOp(op_info, graph->valid_places());
+    auto& cast_op = matched.at("cast")->AsStmt();
+    auto cast_op_desc = *cast_op.op_info();
+    auto in_dtype = cast_op_desc.GetAttr<int>("in_dtype");
+    auto out_dtype = cast_op_desc.GetAttr<int>("out_dtype");
+    // ====================== DEBUG INFO =========================
+    VLOG(6) << "in_dtype : " << in_dtype;
+    VLOG(6) << "out_dtype : " << out_dtype;
+    // ====================== DEBUG END  =========================
+    GraphSafeRemoveNodes(graph, {matched.at("cast")});
+
+    IR_NODE_LINK_TO(matched.at("preop"), matched.at("out"));
+  }
+  int dtype_ = -1;
+};
+
+}  // namespace
+
+class IdentityCastEliminatePass : public ProgramPass {
+ public:
+  void Apply(const std::unique_ptr<SSAGraph>& graph) override {
+    // const int BOOL = 0;
+    // const int INT16 = 1;
+    const int INT32 = 2;
+    // const int INT64 = 3;
+    // const int FP16 = 4;
+    // const int FP32 = 5;
+    // const int FP64 = 6;
+    // const int UINT8 = 20;
+    // const int INT8 = 21;
+    CastEliminator eliminator_int32(INT32);
+    eliminator_int32(graph.get());
+  }
+};
+
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_MIR_PASS(identity_cast_eliminate_pass,
+                  paddle::lite::mir::IdentityCastEliminatePass)
+    .BindTargets({TARGET(kAny)});

--- a/lite/core/optimizer.h
+++ b/lite/core/optimizer.h
@@ -73,7 +73,6 @@ class Optimizer {
            "lite_interpolate_fuse_pass",                  //
            "identity_scale_eliminate_pass",               //
            "elementwise_mul_constant_eliminate_pass",     //
-           "lite_sequence_pool_concat_fuse_pass",         //
 #if (defined LITE_WITH_LIGHT_WEIGHT_FRAMEWORK) || (defined LITE_WITH_CUDA) || \
     (defined LITE_WITH_ARM)
            "lite_elementwise_add_activation_fuse_pass",  //
@@ -91,6 +90,9 @@ class Optimizer {
            "bm_subgraph_pass",
            "rknpu_subgraph_pass",
            "identity_cast_eliminate_pass",
+           "mlu_subgraph_pass",
+           "lite_sequence_pool_concat_fuse_pass",  //
+           "mlu_subgraph_pass",
            "static_kernel_pick_pass",        // pick original kernel from graph
            "variable_place_inference_pass",  // inference arg/var's
 

--- a/lite/core/optimizer.h
+++ b/lite/core/optimizer.h
@@ -90,8 +90,7 @@ class Optimizer {
            "xpu_subgraph_pass",
            "bm_subgraph_pass",
            "rknpu_subgraph_pass",
-           "mlu_subgraph_pass",
-
+           "identity_cast_eliminate_pass",
            "static_kernel_pick_pass",        // pick original kernel from graph
            "variable_place_inference_pass",  // inference arg/var's
 

--- a/lite/core/optimizer.h
+++ b/lite/core/optimizer.h
@@ -73,6 +73,7 @@ class Optimizer {
            "lite_interpolate_fuse_pass",                  //
            "identity_scale_eliminate_pass",               //
            "elementwise_mul_constant_eliminate_pass",     //
+           "lite_sequence_pool_concat_fuse_pass",         //
 #if (defined LITE_WITH_LIGHT_WEIGHT_FRAMEWORK) || (defined LITE_WITH_CUDA) || \
     (defined LITE_WITH_ARM)
            "lite_elementwise_add_activation_fuse_pass",  //
@@ -90,8 +91,6 @@ class Optimizer {
            "bm_subgraph_pass",
            "rknpu_subgraph_pass",
            "identity_cast_eliminate_pass",
-           "mlu_subgraph_pass",
-           "lite_sequence_pool_concat_fuse_pass",  //
            "mlu_subgraph_pass",
            "static_kernel_pick_pass",        // pick original kernel from graph
            "variable_place_inference_pass",  // inference arg/var's


### PR DESCRIPTION
仿照 identity_scale_eliminate_pass，如果存在cast op，它的in_dtype 和 out_dtype 相同，那么将次cast从图中删掉，暂时只支持(int32）